### PR TITLE
write junit test reports as a command line option

### DIFF
--- a/unittest2.nim
+++ b/unittest2.nim
@@ -483,7 +483,7 @@ proc writeSuite(s: Stream, suite: JUnitSuite) {.raises: [Exception].} =
 
   let timeStr = counts[4].formatFloat(ffDecimal, precision = 6)
 
-  s.writeLine("\t" & """<testsuite name="$1" tests="$2" failures="$3" errors="$4" skipped="$5" time="%6">""" % [
+  s.writeLine("\t" & """<testsuite name="$1" tests="$2" failures="$3" errors="$4" skipped="$5" time="$6">""" % [
     xmlEscape(suite.name), $counts[0], $counts[1], $counts[2], $counts[3], timeStr])
 
   for test in suite.tests.items():
@@ -730,8 +730,8 @@ template test*(name, body) =
       when declared(testSetupIMPLFlag): testSetupIMPL()
       when declared(testTeardownIMPLFlag):
         defer: testTeardownIMPL()
-
-      body
+      block:
+        body
 
     except Exception as e: # This will also catch Defect which may or may not work
       let eTypeDesc = "[" & exceptionTypeName(e) & "]"

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -119,7 +119,7 @@
 ##     suiteTeardown:
 ##       echo "suite teardown: run once after the tests"
 
-import std/[locks, macros, sets, strutils, streams, times]
+import std/[locks, macros, sets, strutils, streams, times, monotimes]
 
 when declared(stdout):
   import std/os
@@ -185,6 +185,7 @@ type
     testName*: string
       ## Name of the test case
     status*: TestStatus
+    duration*: Duration # How long the test took, in seconds
 
   OutputFormatter* = ref object of RootObj
 
@@ -207,11 +208,21 @@ type
     isInSuite: bool
     isInTest: bool
 
+  JUnitTest = object
+    name: string
+    result: TestResult
+    error: (seq[string], string)
+    failures: seq[seq[string]]
+
+  JUnitSuite = object
+    name: string
+    tests: seq[JUnitTest]
+
   JUnitOutputFormatter* = ref object of OutputFormatter
     stream: Stream
-    testErrors: seq[string]
-    testStartTime: float
-    testStackTrace: string
+    defaultSuite: JUnitSuite
+    suites: seq[JUnitSuite]
+    currentSuite: int
 
 var
   abortOnError* {.threadvar.}: bool ## Set to true in order to quit
@@ -259,6 +270,11 @@ method failureOccurred*(formatter: OutputFormatter, checkpoints: seq[string],
 method testEnded*(formatter: OutputFormatter, testResult: TestResult) {.base, gcsafe.} =
   discard
 method suiteEnded*(formatter: OutputFormatter) {.base, gcsafe.} =
+  discard
+method testRunEnded*(formatter: OutputFormatter) {.base, gcsafe.} =
+  # Runs when the test executable is about to end, which is implemented using
+  # addQuitProc, a best-effort kind of place to do cleanups
+
   discard
 
 proc addOutputFormatter*(formatter: OutputFormatter) =
@@ -383,95 +399,113 @@ proc newJUnitOutputFormatter*(stream: Stream): JUnitOutputFormatter =
   ## You should invoke formatter.close() to finalize the report.
   result = JUnitOutputFormatter(
     stream: stream,
-    testErrors: @[],
-    testStackTrace: "",
-    testStartTime: 0.0
+    defaultSuite: JUnitSuite(name: "default"),
+    currentSuite: -1,
   )
   try:
     stream.writeLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
-    stream.writeLine("<testsuites>")
   except CatchableError as exc:
     echo "Cannot write JUnit: ", exc.msg
     quit 1
 
-proc close*(formatter: JUnitOutputFormatter) =
-  ## Completes the report and closes the underlying stream.
-  try:
-    formatter.stream.writeLine("</testsuites>")
-    formatter.stream.close()
-  except Exception as exc: # Work around Exception raised in stream
-    echo "Cannot write JUnit: ", exc.msg
-    quit 1
+template suite(formatter: JUnitOutputFormatter): untyped =
+  if formatter.currentSuite == -1:
+    addr formatter.defaultSuite
+  else:
+    addr formatter.suites[formatter.currentSuite]
 
 method suiteStarted*(formatter: JUnitOutputFormatter, suiteName: string) =
-  try:
-    formatter.stream.writeLine("\t<testsuite name=\"$1\">" % xmlEscape(suiteName))
-  except CatchableError as exc:
-    echo "Cannot write JUnit: ", exc.msg
-    quit 1
+  formatter.currentSuite = formatter.suites.len()
+  formatter.suites.add(JUnitSuite(name: suiteName))
 
 method testStarted*(formatter: JUnitOutputFormatter, testName: string) =
-  formatter.testErrors.setLen(0)
-  formatter.testStackTrace.setLen(0)
-  formatter.testStartTime = epochTime()
+  formatter.suite().tests.add(JUnitTest(name: testName))
 
 method failureOccurred*(formatter: JUnitOutputFormatter,
                         checkpoints: seq[string], stackTrace: string) =
   ## ``stackTrace`` is provided only if the failure occurred due to an exception.
   ## ``checkpoints`` is never ``nil``.
-  formatter.testErrors.add(checkpoints)
   if stackTrace.len > 0:
-    formatter.testStackTrace = stackTrace
+    formatter.suite().tests[^1].error = (checkpoints, stackTrace)
+  else:
+    formatter.suite().tests[^1].failures.add(checkpoints)
 
 method testEnded*(formatter: JUnitOutputFormatter, testResult: TestResult) =
-  let time = epochTime() - formatter.testStartTime
-  let timeStr = time.formatFloat(ffDecimal, precision = 8)
-  try:
-    formatter.stream.writeLine("\t\t<testcase name=\"$#\" time=\"$#\">" % [
-        xmlEscape(testResult.testName), timeStr])
-    case testResult.status
+  formatter.suite().tests[^1].result = testResult
+
+method suiteEnded*(formatter: JUnitOutputFormatter) =
+  formatter.currentSuite = -1
+
+func toFloatSeconds(duration: Duration): float64 =
+  duration.inNanoseconds().float64 / 1_000_000_000.0
+
+proc writeTest(s: Stream, test: JUnitTest) {.raises: [Exception].} =
+  let
+    time = test.result.duration.toFloatSeconds()
+    timeStr = time.formatFloat(ffDecimal, precision = 6)
+
+  s.writeLine("\t\t<testcase name=\"$#\" time=\"$#\">" % [
+      xmlEscape(test.name), timeStr])
+  case test.result.status
+  of TestStatus.OK:
+    discard
+  of TestStatus.SKIPPED:
+    s.writeLine("\t\t\t<skipped />")
+  of TestStatus.FAILED:
+    if test.error[0].len > 0:
+      s.writeLine("\t\t\t<error message=\"$#\">$#</error>" % [
+          xmlEscape(join(test.error[0], "\n")), xmlEscape(test.error[1])])
+
+    for failure in test.failures:
+      s.writeLine("\t\t\t<failure message=\"$#\">$#</failure>" %
+          [xmlEscape(failure[^1]), xmlEscape(join(failure[0..^2], "\n"))])
+
+  s.writeLine("\t\t</testcase>")
+
+proc countTests(counts: var (int, int, int, int, float), suite: JUnitSuite) =
+  counts[0] += suite.tests.len()
+  for test in suite.tests:
+    counts[4] += test.result.duration.toFloatSeconds()
+    case test.result.status
     of TestStatus.OK:
       discard
     of TestStatus.SKIPPED:
-      formatter.stream.writeLine("<skipped />")
+      counts[3] += 1
     of TestStatus.FAILED:
-      let failureMsg = if formatter.testStackTrace.len > 0 and
-                          formatter.testErrors.len > 0:
-                        xmlEscape(formatter.testErrors[^1])
-                      elif formatter.testErrors.len > 0:
-                        xmlEscape(formatter.testErrors[0])
-                      else: "The test failed without outputting an error"
-
-      var errs = ""
-      if formatter.testErrors.len > 1:
-        var startIdx = if formatter.testStackTrace.len > 0: 0 else: 1
-        var endIdx = if formatter.testStackTrace.len > 0:
-                        formatter.testErrors.len - 2
-                      else: formatter.testErrors.len - 1
-
-        for errIdx in startIdx..endIdx:
-          if errs.len > 0:
-            errs.add("\n")
-          errs.add(xmlEscape(formatter.testErrors[errIdx]))
-
-      if formatter.testStackTrace.len > 0:
-        formatter.stream.writeLine("\t\t\t<error message=\"$#\">$#</error>" % [
-            failureMsg, xmlEscape(formatter.testStackTrace)])
-        if errs.len > 0:
-          formatter.stream.writeLine("\t\t\t<system-err>$#</system-err>" % errs)
+      if test.error[0].len > 0:
+        counts[2] += 1
       else:
-        formatter.stream.writeLine("\t\t\t<failure message=\"$#\">$#</failure>" %
-            [failureMsg, errs])
+        counts[1] += 1
 
-    formatter.stream.writeLine("\t\t</testcase>")
-  except CatchableError as exc:
-    echo "Cannot write JUnit: ", exc.msg
-    quit 1
+proc writeSuite(s: Stream, suite: JUnitSuite) {.raises: [Exception].} =
+  var counts: (int, int, int, int, float)
+  countTests(counts, suite)
 
-method suiteEnded*(formatter: JUnitOutputFormatter) =
+  let timeStr = counts[4].formatFloat(ffDecimal, precision = 6)
+
+  s.writeLine("\t" & """<testsuite name="$1" tests="$2" failures="$3" errors="$4" skipped="$5" time="%6">""" % [
+    xmlEscape(suite.name), $counts[0], $counts[1], $counts[2], $counts[3], timeStr])
+
+  for test in suite.tests.items():
+    s.writeTest(test)
+
+  s.writeLine("\t</testsuite>")
+
+method testRunEnded*(formatter: JUnitOutputFormatter) =
+  ## Completes the report and closes the underlying stream.
+  let s = formatter.stream
   try:
-    formatter.stream.writeLine("\t</testsuite>")
-  except CatchableError as exc:
+    s.writeLine("<testsuites>")
+
+    for suite in formatter.suites.mitems():
+      s.writeSuite(suite)
+
+    if formatter.defaultSuite.tests.len() > 0:
+      s.writeSuite(formatter.defaultSuite)
+
+    s.writeLine("</testsuites>")
+    s.close()
+  except Exception as exc: # Work around Exception raised in stream
     echo "Cannot write JUnit: ", exc.msg
     quit 1
 
@@ -526,19 +560,43 @@ proc shouldRun(currentSuiteName, testName: string): bool =
 
   return false
 
-proc ensureInitialized() =
-  withLock formattersLock:
-    {.gcsafe.}:
-      if formatters.len == 0:
-        formatters = @[OutputFormatter(defaultConsoleFormatter())]
+proc cleanupFormatters() {.noconv.} =
+  withLock(formattersLock):
+    for f in formatters.mitems():
+      testRunEnded(f)
 
+proc ensureInitialized() =
   withLock testFiltersLock:
-    {.gcsafe.}:
-      if not disabledParamFiltering:
-        when declared(paramCount):
-          # Read tests to run from the command line.
-          for i in 1 .. paramCount():
-            testsFilters.incl(paramStr(i))
+    withLock formattersLock:
+      {.gcsafe.}:
+        if not disabledParamFiltering:
+          when declared(paramCount):
+            # Read tests to run from the command line.
+            for i in 1 .. paramCount():
+              let str = paramStr(i)
+              if str.startsWith("--help"):
+                echo "Usage: [--xml=file.xml] [--console] [test-name-glob]"
+                quit 0
+              elif str.startsWith("--xml"):
+                let fn = str[("--xml".len + 1)..^1] # skip separator char as well
+                try:
+                  formatters.add(newJUnitOutputFormatter(
+                    newFileStream(fn, fmWrite)))
+                except CatchableError as exc:
+                  echo "Cannot open ", fn, " for writing: ", exc.msg
+                  quit 1
+              elif str.startsWith("--console"):
+                formatters.add(defaultConsoleFormatter())
+              else:
+                testsFilters.incl(str)
+
+        if formatters.len == 0:
+          # no need for cleanup of console formatter
+          formatters = @[OutputFormatter(defaultConsoleFormatter())]
+        else:
+          addQuitProc(cleanupFormatters)
+
+ensureInitialized() # Run once!
 
 proc suiteStarted(name: string) =
   when paralleliseTests:
@@ -603,7 +661,7 @@ template suite*(name, body) {.dirty.} =
   ##  [Suite] test suite for addition
   ##    [OK] 2 + 2 = 4
   ##    [OK] (2 + -2) != 4
-  bind formatters, ensureInitialized, suiteStarted, suiteEnded
+  bind formatters, suiteStarted, suiteEnded
 
   block:
     template setup(setupBody: untyped) {.dirty, used.} =
@@ -620,7 +678,6 @@ template suite*(name, body) {.dirty.} =
 
     let testSuiteName {.used.} = name
 
-    ensureInitialized()
     try:
       suiteStarted(name)
       body
@@ -647,7 +704,7 @@ template test*(name, body) =
   ## .. code-block::
   ##
   ##  [OK] roses are red
-  bind shouldRun, checkpoints, ensureInitialized, testEnded, exceptionTypeName
+  bind shouldRun, checkpoints, testEnded, exceptionTypeName
   withLock formattersLock:
     {.gcsafe.}:
       bind formatters
@@ -662,13 +719,13 @@ template test*(name, body) =
     {.pragma: testrunner.}
 
   proc runTest(testSuiteName: string, testName: string): int {.gensym, testrunner.} =
-    ensureInitialized()
-
     checkpoints = @[]
     var testStatusIMPL {.inject.} = TestStatus.OK
     let testName {.inject.} = testName
 
     testStarted(testName)
+    let startTime = getMonoTime()
+
     try:
       when declared(testSetupIMPLFlag): testSetupIMPL()
       when declared(testTeardownIMPLFlag):
@@ -691,7 +748,8 @@ template test*(name, body) =
       let testResult = TestResult(
         suiteName: testSuiteName,
         testName: name,
-        status: testStatusIMPL
+        status: testStatusIMPL,
+        duration: getMonoTime() - startTime
       )
       testEnded(testResult)
       checkpoints = @[]
@@ -730,13 +788,10 @@ template fail* =
   ##  fail()
   ##
   ## outputs "Checkpoint A" before quitting.
-  bind ensureInitialized
   when declared(testStatusIMPL):
     testStatusIMPL = TestStatus.FAILED
   else:
     programResult = 1
-
-  ensureInitialized()
 
   withLock formattersLock:
     {.gcsafe.}:


### PR DESCRIPTION
* add counters to xml reports
* add command line args to write xml report
* fix initialization being performed once for each test
* use monotonic timer for duration measurements