### PR TITLE
Add -d:unittestPrintTime to show test duration in console

### DIFF
--- a/unittest2.nim
+++ b/unittest2.nim
@@ -369,9 +369,18 @@ method testEnded*(formatter: ConsoleOutputFormatter, testResult: TestResult) =
 
   if formatter.outputLevel != OutputLevel.PRINT_NONE and
       (formatter.outputLevel == OutputLevel.PRINT_ALL or testResult.status == TestStatus.FAILED):
-    let prefix = if testResult.suiteName.len > 0: "  " else: ""
-    template rawPrint() = echo(prefix, "[", $testResult.status, "] ",
-        testResult.testName)
+    let
+      prefix = if testResult.suiteName.len > 0: "  " else: ""
+      testHeader =
+        when defined(unittestPrintTime):
+          let
+            seconds = testResult.duration.inMilliseconds.float / 1000.0
+            precision = max(3 - ($seconds.int).len, 1)
+            formattedSeconds = formatFloat(seconds, ffDecimal, precision)
+          prefix & "[" & $testResult.status & " - " & formattedSeconds & "s] "
+        else:
+          prefix & "[" & $testResult.status & "] "
+    template rawPrint() = echo(testHeader, testResult.testName)
     when useTerminal:
       if formatter.colorOutput:
         var color = case testResult.status
@@ -379,7 +388,7 @@ method testEnded*(formatter: ConsoleOutputFormatter, testResult: TestResult) =
           of TestStatus.FAILED: fgRed
           of TestStatus.SKIPPED: fgYellow
         try:
-          styledEcho styleBright, color, prefix, "[", $testResult.status, "] ",
+          styledEcho styleBright, color, testHeader,
               resetStyle, testResult.testName
         except Exception: rawPrint() # Work around exceptions in `terminal.nim`
       else:


### PR DESCRIPTION
It's behind a flag, but we can enable it by default if it's useful for everyone

With CI getting bloated on a lot of projects, I think it's very useful