### PR TITLE
avoid potential capture of lent iterator var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    timeout-minutes: 15
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/unittest2.nimble
+++ b/unittest2.nimble
@@ -1,6 +1,6 @@
 mode = ScriptMode.Verbose
 
-version       = "0.0.7"
+version       = "0.0.8"
 author        = "Status Research & Development GmbH"
 description   = "unittest fork with support for parallel test execution"
 license       = "MIT"


### PR DESCRIPTION
also avoid `quote do` for better line numbers in error messages