### PR TITLE
unittest2.nim: ensure the testTeardownIMPL is performed at the end

### DIFF
--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1128,7 +1128,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
       try:
         when declared(testTeardownIMPLFlag):
           testTeardownIMPL()
-      except CatchableError:
+      except CatchableError, Defect, Exception:
         checkpoint("Exception when calling testTeardownIMPL: " & getCurrentExceptionMsg())
         fail()
 

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1105,8 +1105,6 @@ template runtimeTest*(nameParam: string, body: untyped) =
 
     try:
       when declared(testSetupIMPLFlag): testSetupIMPL()
-      when declared(testTeardownIMPLFlag):
-        defer: testTeardownIMPL()
       block:
         body
 
@@ -1126,6 +1124,13 @@ template runtimeTest*(nameParam: string, body: untyped) =
       checkpoint("Unhandled exception that may cause undefined behavior: " & e.msg & " " & eTypeDesc)
       var stackTrace {.inject.} = e.getStackTrace()
       fail()
+    finally:
+      try:
+        when declared(testTeardownIMPLFlag):
+          testTeardownIMPL()
+      except CatchableError:
+        checkpoint("Exception when calling testTeardownIMPL: " & getCurrentExceptionMsg())
+        fail()
 
     checkpoints = @[]
 

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1128,8 +1128,10 @@ template runtimeTest*(nameParam: string, body: untyped) =
       try:
         when declared(testTeardownIMPLFlag):
           testTeardownIMPL()
-      except CatchableError, Defect, Exception:
-        checkpoint("Exception when calling testTeardownIMPL: " & getCurrentExceptionMsg())
+      except Exception as e:
+        let eTypeDesc = "[" & $e.name & "]"
+        checkpoint("Exception when calling teardown: " & e.msg & " " & eTypeDesc)
+        var stackTrace {.inject.} = e.getStackTrace()
         fail()
 
     checkpoints = @[]


### PR DESCRIPTION
This is important to prevent "failing tests" from failing in an uncontrolled way and generating a SIGSEGV (segmentation fault)

Particularly, when the test body raises an exception, e.g. "assert false", what happened was that the "testTeardownIMPL" was invoked before the exception handling, and that caused errors like:

```
Traceback (most recent call last, using override)
/home/ivansete/workspace/status/nwaku/vendor/nim-unittest2/unittest2.nim(1154) unittest2
/home/ivansete/workspace/status/nwaku/vendor/nim-unittest2/unittest2.nim(1086) runDirect
/home/ivansete/workspace/status/nwaku/vendor/nim-unittest2/unittest2.nim(1111) runTestX60gensym398
/home/ivansete/workspace/status/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(631) signalHandler
SIGSEGV: Illegal storage access. (Attempt to read from nil?) Segmentation fault (core dumped)
```