### PR TITLE
fix: issue 43

### DIFF
--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -242,7 +242,8 @@ suite "break should works inside test body":
     check number == 2
 
 suite "Issue #43":
-  proc p = fail()
+  proc testfail = fail()
+  proc testcheckfalse = check false
 
   teardown:
     if testStatusObj.status != TestStatus.FAILED:
@@ -253,5 +254,8 @@ suite "Issue #43":
       testStatusObj.status = TestStatus.OK
       exitProcs.setProgramResult(QuitSuccess)
 
-  test "procedure defined outside the test scope fails":
-    p()
+  test "calls a procedure which fails and is defined outside the test scope":
+    testfail()
+
+  test "calls a procedure which checks false and is defined outside the test scope":
+    testcheckfalse()

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -34,12 +34,14 @@ suite "PR #35":
     doAssert(true)
 
   teardown:
-    if testStatusIMPL != TestStatus.FAILED:
+    if testStatusIMPL != TestStatus.FAILED or testStatusObj.status != TestStatus.FAILED:
       testStatusIMPL = TestStatus.FAILED
+      testStatusObj.status = TestStatus.FAILED
       exitProcs.setProgramResult(QuitFailure)
       debugEcho "PR #35 test FAILED"
     else:
       testStatusIMPL = TestStatus.OK
+      testStatusObj.status = TestStatus.OK
       exitProcs.setProgramResult(QuitSuccess)
 
   test "something":
@@ -238,3 +240,18 @@ suite "break should works inside test body":
     number = 3
   test "step three":
     check number == 2
+
+suite "Issue #43":
+  proc p = fail()
+
+  teardown:
+    if testStatusObj.status != TestStatus.FAILED:
+      testStatusObj.status = TestStatus.FAILED
+      exitProcs.setProgramResult(QuitFailure)
+      debugEcho "Issue #43 test FAILED"
+    else:
+      testStatusObj.status = TestStatus.OK
+      exitProcs.setProgramResult(QuitSuccess)
+
+  test "procedure defined outside the test scope fails":
+    p()


### PR DESCRIPTION
Should fix #43.

To summarize the problem: `testStatusIMPL` is the variable which is used know if a test succeeded, failed or has been skipped.
`testStatusIMPL` is defined in the `test` scope, calling check / fail outside this scope (like in the issue) will cause `testStatusIMPL` to not be declared and, as a consequence, not to be set to FAILED or SKIPPED.

The solution was to create another variable which is a global variable, thus it is always present and can be set even outside the `test` scope.

The solution is clearly a roundabout and is a bit inelegant. But I haven't found any other way to solve this issue.