### PR TITLE
Ensure test is marked as failed when check is inside `proc`

### DIFF
--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -238,3 +238,13 @@ suite "break should works inside test body":
     number = 3
   test "step three":
     check number == 2
+
+suite "checks in `proc` should work":
+  teardown:
+    require testStatusIMPL == TestStatus.Failed
+    testStatusIMPL = TestStatus.OK
+
+  proc checkFalse() = check false
+
+  test "test":
+    checkFalse()

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -60,6 +60,17 @@ suite "PR #36":
     server = new(string)
     server[] = "hello"
 
+suite "checks in `proc` should work":
+  teardown:
+    require testStatusIMPL == TestStatus.Failed
+    testStatusIMPL = TestStatus.OK
+    exitProcs.setProgramResult(QuitSuccess)
+
+  proc checkFalse() = check false
+
+  test "test":
+    checkFalse()
+
 #------------------------------------------------------------------------------
 # Regular tests
 #------------------------------------------------------------------------------
@@ -238,13 +249,3 @@ suite "break should works inside test body":
     number = 3
   test "step three":
     check number == 2
-
-suite "checks in `proc` should work":
-  teardown:
-    require testStatusIMPL == TestStatus.Failed
-    testStatusIMPL = TestStatus.OK
-
-  proc checkFalse() = check false
-
-  test "test":
-    checkFalse()

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1100,6 +1100,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
 
   proc runTest(suiteName, testName: string): TestStatus {.raises: [], gensym.} =
     testStatus = TestStatus.OK
+    template testStatusIMPL: untyped {.inject, used.} = testStatus
     let suiteName {.inject, used.} = suiteName
     let testName {.inject, used.} = testName
 

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1100,7 +1100,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
 
   proc runTest(suiteName, testName: string): TestStatus {.raises: [], gensym.} =
     testStatus = TestStatus.OK
-    template testStatusIMPL: untyped {.inject, used.} = testStatus
+    template testStatusIMPL: var TestStatus {.inject, used.} = testStatus
     let suiteName {.inject, used.} = suiteName
     let testName {.inject, used.} = testName
 

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -271,6 +271,7 @@ var
   testsFilters {.threadvar.}: HashSet[string]
 
   currentSuite {.threadvar.}: string
+  testStatus {.threadvar.}: TestStatus
 
 when collect:
   var
@@ -1025,8 +1026,7 @@ template fail* =
     echo "Tests failed"
     quit 1
   else:
-    when declared(testStatusIMPL):
-      testStatusIMPL = TestStatus.FAILED
+    testStatus = TestStatus.FAILED
 
     exitProcs.setProgramResult(1)
 
@@ -1060,7 +1060,7 @@ template skip* =
   else:
     bind checkpoints
 
-    testStatusIMPL = TestStatus.SKIPPED
+    testStatus = TestStatus.SKIPPED
     checkpoints = @[]
 
 proc runDirect(test: Test) =
@@ -1099,7 +1099,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
   bind collect, runDirect, shouldRun, checkpoints
 
   proc runTest(suiteName, testName: string): TestStatus {.raises: [], gensym.} =
-    var testStatusIMPL {.inject.} = TestStatus.OK
+    testStatus = TestStatus.OK
     let suiteName {.inject, used.} = suiteName
     let testName {.inject, used.} = testName
 
@@ -1133,7 +1133,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
 
     checkpoints = @[]
 
-    testStatusIMPL
+    testStatus
 
   let
     localSuiteName =


### PR DESCRIPTION
The `testStatusIMPL` injection does not go into nested `proc`, so the `testStatusIMPL = TestStatus.FAILED` line was not called leading to test failures being incorrectly suppressed.