### PR TITLE
Adds the `listTests` compile time flag

### DIFF
--- a/tests/sampletests.nim
+++ b/tests/sampletests.nim
@@ -1,0 +1,19 @@
+import ../unittest2
+
+suite "Sample Tests":
+  test "Sample Test":
+    check(1 == 1)
+
+test "Global test":
+  check(1 == 1)
+
+suite "Sample Suite":
+  test "Sample Test":
+    check(1 == 1)
+
+  test "Sample Test 2":
+    check(1 == 1)
+
+  test "Sample Test 3":
+    check(1 == 1)
+

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -22,6 +22,7 @@ discard """
 
 import ../unittest2, sequtils
 from std/exitprocs import nil
+import std/[osproc, strutils]
 
 #------------------------------------------------------------------------------
 # Tests using backdoors
@@ -256,3 +257,13 @@ suite "break should works inside test body":
     number = 3
   test "step three":
     check number == 2
+
+suite "list tests":
+  test "should list tests when `-d:listTests` is passed":    
+
+    let (output, exitCode) = execCmdEx("nim c -d:listTests tests/sampletests.nim")
+    
+    check exitCode == 0
+    check count(output, "Suite:") == 2
+    check count(output, "Test:") == 5
+    check count(output, "File:") == 5

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -160,6 +160,7 @@ const
     ## enabled at compile-time meaning that tests must be written
     ## conservatively. `suite` features (`setup` etc) in particular are not
     ## supported.
+  listTests* {.booldefine.} = false #List tests at compile time (useful for test runners)
 
 when useTerminal:
   import std/terminal
@@ -955,6 +956,10 @@ template suite*(nameParam: string, body: untyped) {.dirty.} =
   ##    [OK] (2 + -2) != 4
   bind collect, currentSuite, suiteStarted, suiteEnded
 
+  when listTests:
+    static:
+      echo "\nSuite: ", nameParam
+  
   block:
     template setup(setupBody: untyped) {.dirty, used.} =
       var testSetupIMPLFlag {.used.} = true
@@ -1189,6 +1194,15 @@ template test*(nameParam: string, body: untyped) =
   ## .. code-block::
   ##
   ##  [OK] roses are red
+  when listTests:
+    static:
+      when declared(suiteName):
+        echo "\tTest: ", nameParam
+        echo "\tFile: ", instantiationInfo().filename, ":", instantiationInfo().line
+      else:
+        echo "Test: ", nameParam
+        echo "File: ", instantiationInfo().filename, ":", instantiationInfo().line
+      echo ""
   when nimvm:
     when unittest2Static:
       staticTest nameParam:


### PR DESCRIPTION
Running: 
`nim c   -d:listTests tests/sampletests.nim`

Will result in: 

```
Hint: used config file '/Volumes/Store/Nim/config/nim.cfg' [Conf]
Hint: used config file '/Volumes/Store/Nim/config/config.nims' [Conf]
Hint: used config file '/Volumes/Store/Projects/nim-unittest2/nim.cfg' [Conf]
Hint: used config file '/Volumes/Store/Projects/nim-unittest2/config.nims' [Conf]
Hint: used config file '/Volumes/Store/Projects/nim-unittest2/tests/nim.cfg' [Conf]
....................................................................................................................................

Suite: Sample Tests
  Test: Sample Test
    File: sampletests.nim:4

Test: Global test
    File: sampletests.nim:8


Suite: Sample Suite
  Test: Sample Test
    File: sampletests.nim:12

  Test: Sample Test 2
    File: sampletests.nim:15

  Test: Sample Test 3
    File: sampletests.nim:18
   ```
   
   Allowing external tools (i.e. a test runner) to gather test information without actually running the tests