### PR TITLE
Fix ref check in VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docs/
 /nimble.develop
 *.exe
 test_results.xml
+tests/sampletests
+/build

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -184,6 +184,14 @@ suite "bug #5784":
     var obj: Obj
     check obj.isNil or obj.field == 0
 
+suite "PR #56":
+  test "object ref field check":
+    type Obj = object
+      field: ref int
+    var obj = Obj(field: new(int))
+    obj.field[] = 123
+    check obj.field[] == 123
+
 type
     SomeType = object
         value: int

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1215,8 +1215,6 @@ template test*(nameParam: string, body: untyped) =
 
 iterator unittest2EvalOnceIter[T](x: T): auto =
   yield x
-iterator unittest2EvalOnceIter[T](x: var T): var T =
-  yield x
 
 template unittest2EvalOnce(name: untyped, param: typed, blk: untyped) =
   for name in unittest2EvalOnceIter(param):


### PR DESCRIPTION
Remove `unittest2EvalOnceIter(var T): var T` to avoid running into the "reference (pointer) types" [VM limitation](https://nim-lang.org/docs/manual.html#restrictions-on-compileminustime-execution) for var ref check at comptime/in the VM.

Alternatively the template could be defined when not in nimvm, but I don't think it's needed unless it's there to workaround some Nim copy bug?