### PR TITLE
Support nested tests at comptime

### DIFF
--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -194,6 +194,13 @@ suite "PR #59":
     dualTest "inner test":
       checkpoint "nested dual test CP"
       check 1 == 1
+ 
+  staticTest "Nested test":
+    template testInStatic(): untyped =
+      static:
+        test "inner test":
+          check 1 == 1
+    check(not compiles(testInStatic()))
 
 type
     SomeType = object

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -195,7 +195,7 @@ suite "PR #59":
       checkpoint "nested dual test CP"
       check 1 == 1
  
-  staticTest "Nested test":
+  staticTest "Test within static is not allowed":
     template testInStatic(): untyped =
       static:
         test "inner test":

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -185,19 +185,14 @@ suite "bug #5784":
     check obj.isNil or obj.field == 0
 
 suite "PR #59":
-  staticTest "Nested test":
-    test "inner test":
-      checkpoint "foobar"
-      check 1 == 1
-
   staticTest "Nested static test":
     staticTest "inner test":
-      checkpoint "foobar"
+      checkpoint "nested static test CP"
       check 1 == 1
 
   dualTest "Nested dual test":
     dualTest "inner test":
-      checkpoint "foobar"
+      checkpoint "nested dual test CP"
       check 1 == 1
 
 type

--- a/tests/tunittest.nim
+++ b/tests/tunittest.nim
@@ -184,6 +184,22 @@ suite "bug #5784":
     var obj: Obj
     check obj.isNil or obj.field == 0
 
+suite "PR #59":
+  staticTest "Nested test":
+    test "inner test":
+      checkpoint "foobar"
+      check 1 == 1
+
+  staticTest "Nested static test":
+    staticTest "inner test":
+      checkpoint "foobar"
+      check 1 == 1
+
+  dualTest "Nested dual test":
+    dualTest "inner test":
+      checkpoint "foobar"
+      check 1 == 1
+
 type
     SomeType = object
         value: int

--- a/tests/tunittest_vm.nim
+++ b/tests/tunittest_vm.nim
@@ -1,0 +1,13 @@
+{.define: unittest2Static.}
+
+import ../unittest2
+
+suite "VM test":
+  test "Simple test":
+    checkpoint "simple test CP"
+    check 1 == 1
+
+  test "Nested test":
+    test "inner test":
+      checkpoint "nested test CP"
+      check 1 == 1

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1010,9 +1010,6 @@ template checkpoint*(msg: string) =
   ##
   ## outputs "Checkpoint A" once it fails.
   when nimvm:
-    when compiles(testName):
-      echo testName
-
     echo msg
   else:
     bind checkpoints
@@ -1181,12 +1178,14 @@ template staticTest*(nameParam: string, body: untyped) =
 template dualTest*(nameParam: string, body: untyped) =
   ## Similar to `test` but run the test both compuletime and run time, no
   ## matter the `unittest2Static` flag
-  staticTest nameParam:
-    when not unittest2ListTests:
-      body
-  runtimeTest nameParam:
-    when not unittest2ListTests:
-      body
+  when nimvm:
+    staticTest nameParam:
+      when not unittest2ListTests:
+        body
+  else:
+    runtimeTest nameParam:
+      when not unittest2ListTests:
+        body
 
 template test*(nameParam: string, body: untyped) =
   ## Define a single test case identified by `name`.
@@ -1207,9 +1206,10 @@ template test*(nameParam: string, body: untyped) =
       staticTest nameParam:
         when not unittest2ListTests:
           body
-  runtimeTest nameParam:
-    when not unittest2ListTests:
-      body
+  else:
+    runtimeTest nameParam:
+      when not unittest2ListTests:
+        body
 
 {.pop.} # raises: []
 

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1206,6 +1206,8 @@ template test*(nameParam: string, body: untyped) =
       staticTest nameParam:
         when not unittest2ListTests:
           body
+    else:
+      error "`unittest2Static` needs to be defined to run test in Nim VM"
   else:
     runtimeTest nameParam:
       when not unittest2ListTests:


### PR DESCRIPTION
Changes:

- Support nested tests at comptime. The VM fails to evaluate nested runtimeTests, it cannot evaluate suiteName in `declared(suiteName)` (may be a vm bug).
- Support checkpoint in nested tests. Similarly the VM fails to evaluate testName in `compiles(testName)`, which is no longer needed because of #60.

Moved the checkpoint output improvement to #60