### PR TITLE
chore: wrap all global variables inside single type

### DIFF
--- a/unittest2.nim
+++ b/unittest2.nim
@@ -958,7 +958,7 @@ template suite*(nameParam: string, body: untyped) {.dirty.} =
   ##  [Suite] test suite for addition
   ##    [OK] 2 + 2 = 4
   ##    [OK] (2 + -2) != 4
-  bind collect, suiteStarted, suiteEnded
+  bind collect, suiteStarted, suiteEnded, globals
 
   block:
     template setup(setupBody: untyped) {.dirty, used.} =

--- a/unittest2.nim
+++ b/unittest2.nim
@@ -1143,7 +1143,7 @@ template runtimeTest*(nameParam: string, body: untyped) =
 
     globals.checkpoints = @[]
 
-    globals.testStatus
+    return globals.testStatus
 
   let
     localSuiteName =


### PR DESCRIPTION
this pr moves all global variables to type `globalsWrap`, by doing so code now uses singe global var where all these values are stored. 
second order impact is that these values are now accessible via `var global` that is  `global.{name}` notation, which improves code readability because we see that we are accessing  `testStatus` from `globals` and not some local value.