### PR TITLE
Remove permissions from doc.yml workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,9 +6,6 @@ on:
       - master
       - cidocs
 
-permissions:
-  contents: read
-
 jobs:
   docs:
     uses: status-im/nimbus-common-workflow/.github/workflows/docs.yml@main


### PR DESCRIPTION
Deployment failed probably because of too restrictive permissions.